### PR TITLE
Update `nan` to `2.23.0` to support Node 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x]
+                node-version: [16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x]
 
         steps:
             - name: Install libcrack2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20.x, 22.x, 24.x]
+                node-version: [20.x, 21.x, 22.x, 23.x, 24.x]
 
         steps:
             - name: Install libcrack2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
+                node-version: [12.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x, 22.x, 24.x]
 
         steps:
             - name: Install libcrack2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x, 22.x, 24.x]
+                node-version: [20.x, 22.x, 24.x]
 
         steps:
             - name: Install libcrack2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20.x, 21.x, 22.x, 23.x, 24.x]
+                node-version: [18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x]
 
         steps:
             - name: Install libcrack2

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.17.0"
+        "nan": "^2.23.0"
       },
       "devDependencies": {
         "mocha": "^10.1.0",
@@ -1170,9 +1170,10 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/landlines/node-cracklib/issues"
   },
   "dependencies": {
-    "nan": "^2.17.0"
+    "nan": "^2.23.0"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
Hello!

💁 This PR addresses a series of compilation errors on Node 24 by upgrading the version of `nan` to `2.23.0`

When installing `cracklib` on `node@24`, we see a slew of compilation errors when `node-gyp` starts to get busy (excerpt below):

```
In file included from ../src/functions.h:7:
../node_modules/nan/nan.h:2546:8: error: no member named 'SetAccessor' in 'v8::ObjectTemplate'
 2546 |   tpl->SetAccessor(
      |   ~~~~~^
../node_modules/nan/nan.h:2592:8: error: no member named 'SetAccessor' in 'v8::ObjectTemplate'
 2592 |   tpl->SetAccessor(
      |   ~~~~~^
../node_modules/nan/nan.h:2636:15: error: no member named 'SetAccessor' in 'v8::Object'
 2636 |   return obj->SetAccessor(
      |          ~~~~~^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```

After digging in and seeing similar errors from other projects related to changes in v8 between Node versions, I decided to upgrade `nan` and see what happens. This breaks a lot of things for EOL versions of Node, but works on all currently maintained LTS versions.

As part of this pull request, I've also removed all EOL releases of Node from the test matrix. If you like, we can probably add in the odd-numbered releases after `node@20` with no impact.